### PR TITLE
Added new fancy table edge and optional name plate model

### DIFF
--- a/img/models.blend
+++ b/img/models.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29310c4f05a705e2c07b28058121bf028fb025b839fad30b6fbdded8c4f3ed7c
-size 837412
+oid sha256:9b51e989ae850cefe9cc00648152494da26d42eeb679c6ef086618259b300e96
+size 1204520


### PR DESCRIPTION
Added two new blender models to models.blend
table_edge: Looks close to the Amos table used in M-League but added built-in nameplate sections for spectator mode
name_plate: a name plate model (optional) which may be used in the future to drop a sick team graphic plus name onto. Unknown how the texture/shading setup needs to be though to get this to work correctly. But for now, the table should be usable.
ichihime-0.png
![image](https://user-images.githubusercontent.com/16394540/93933104-c79f3980-fce6-11ea-8514-c23866e7ea2c.png)
