### PR TITLE
Called tiles auto-rotate when moved to meld slots

### DIFF
--- a/src/movement.ts
+++ b/src/movement.ts
@@ -83,9 +83,13 @@ export class Movement {
           rotationIndex = matchingIndex;
         }
       } else {
-        rotationIndex = thing.slot.group === slot.group
-         ? thing.rotationIndex
-         : Math.max(0, slot.rotationOptions.findIndex(r => r.equals(thing.slot.rotationOptions[thing.rotationIndex])));
+        if (slot.group === 'meld' && thing.slot.group == 'discard') {
+            rotationIndex = 1;
+        } else {
+            rotationIndex = thing.slot.group === slot.group
+             ? thing.rotationIndex
+             : Math.max(0, slot.rotationOptions.findIndex(r => r.equals(thing.slot.rotationOptions[thing.rotationIndex])));
+        }
       }
 
       thing.moveTo(slot, rotationIndex);


### PR DESCRIPTION
Does not account for upside down tiles moved to meld areas--they'll be flipped upright, but this shouldn't happen anyway unless a convoluted form of mahjong is being played.